### PR TITLE
Expose error scope validation messages

### DIFF
--- a/src/c/pkg.generated.mbti
+++ b/src/c/pkg.generated.mbti
@@ -664,6 +664,10 @@ pub fn device_limits_min_uniform_buffer_offset_alignment_u32(WGPUDevice) -> UInt
 
 pub fn device_poll(WGPUDevice, Bool, WGPUSubmissionIndexPtr) -> Bool
 
+pub fn device_pop_error_scope_sync_last_message_utf8(Bytes, UInt64) -> Bool
+
+pub fn device_pop_error_scope_sync_last_message_utf8_len() -> UInt64
+
 pub fn device_pop_error_scope_sync_u32(WGPUInstance, WGPUDevice) -> UInt
 
 pub fn device_push_error_scope_u32(WGPUDevice, UInt) -> Unit

--- a/src/c/raw_adapter_device.mbt
+++ b/src/c/raw_adapter_device.mbt
@@ -715,6 +715,16 @@ pub extern "C" fn device_pop_error_scope_sync_u32(
 ) -> UInt = "mbt_wgpu_device_pop_error_scope_sync"
 
 ///|
+pub extern "C" fn device_pop_error_scope_sync_last_message_utf8_len() -> UInt64 = "mbt_wgpu_device_pop_error_scope_sync_last_message_utf8_len"
+
+///|
+#borrow(out)
+pub extern "C" fn device_pop_error_scope_sync_last_message_utf8(
+  out : Bytes,
+  out_len : UInt64,
+) -> Bool = "mbt_wgpu_device_pop_error_scope_sync_last_message_utf8"
+
+///|
 pub extern "C" fn adapter_request_device_sync(
   instance : Instance,
   adapter : WGPUAdapter,

--- a/src/c/wgpu_stub_extras.c
+++ b/src/c/wgpu_stub_extras.c
@@ -20,6 +20,16 @@
 #include <string.h>
 #include <stdatomic.h>
 
+#if defined(_WIN32)
+#define MBT_WGPU_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define MBT_WGPU_THREAD_LOCAL _Thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define MBT_WGPU_THREAD_LOCAL __thread
+#else
+#define MBT_WGPU_THREAD_LOCAL
+#endif
+
 static _Atomic uint32_t g_mbt_wgpu_debug_budget_u32 = 64u;
 
 static bool mbt_wgpu_debug_take(const char *env_name) {
@@ -1926,19 +1936,39 @@ void mbt_wgpu_device_push_error_scope_u32(WGPUDevice device, uint32_t filter_u32
 typedef struct {
   WGPUPopErrorScopeStatus status;
   WGPUErrorType type;
+  uint8_t *message;
+  uint64_t message_len_u64;
 } mbt_pop_error_scope_result_t;
+
+static MBT_WGPU_THREAD_LOCAL uint8_t *g_mbt_wgpu_last_pop_error_scope_message = NULL;
+static MBT_WGPU_THREAD_LOCAL uint64_t g_mbt_wgpu_last_pop_error_scope_message_len_u64 = 0u;
+
+static void mbt_wgpu_pop_error_scope_clear_last_message(void) {
+  free(g_mbt_wgpu_last_pop_error_scope_message);
+  g_mbt_wgpu_last_pop_error_scope_message = NULL;
+  g_mbt_wgpu_last_pop_error_scope_message_len_u64 = 0u;
+}
 
 static void mbt_pop_error_scope_cb(WGPUPopErrorScopeStatus status, WGPUErrorType type,
                                    WGPUStringView message, void *userdata1,
                                    void *userdata2) {
-  (void)message;
   (void)userdata2;
   mbt_pop_error_scope_result_t *out = (mbt_pop_error_scope_result_t *)userdata1;
   out->status = status;
   out->type = type;
+  out->message = NULL;
+  out->message_len_u64 = 0u;
+  if (message.data && message.length > 0u) {
+    out->message = (uint8_t *)malloc(message.length);
+    if (out->message) {
+      memcpy(out->message, message.data, message.length);
+      out->message_len_u64 = (uint64_t)message.length;
+    }
+  }
 }
 
 uint32_t mbt_wgpu_device_pop_error_scope_sync(WGPUInstance instance, WGPUDevice device) {
+  mbt_wgpu_pop_error_scope_clear_last_message();
   if (!instance || !device) {
     return 0u;
   }
@@ -1955,9 +1985,32 @@ uint32_t mbt_wgpu_device_pop_error_scope_sync(WGPUInstance instance, WGPUDevice 
     wgpuInstanceProcessEvents(instance);
   }
   if (out.status != WGPUPopErrorScopeStatus_Success) {
+    free(out.message);
     return 0u;
   }
+  g_mbt_wgpu_last_pop_error_scope_message = out.message;
+  g_mbt_wgpu_last_pop_error_scope_message_len_u64 = out.message_len_u64;
+  out.message = NULL;
   return (uint32_t)out.type;
+}
+
+uint64_t mbt_wgpu_device_pop_error_scope_sync_last_message_utf8_len(void) {
+  return g_mbt_wgpu_last_pop_error_scope_message_len_u64;
+}
+
+int32_t mbt_wgpu_device_pop_error_scope_sync_last_message_utf8(uint8_t *out,
+                                                               uint64_t out_len) {
+  if (!out) {
+    return 0;
+  }
+  if (out_len < g_mbt_wgpu_last_pop_error_scope_message_len_u64) {
+    return 0;
+  }
+  if (g_mbt_wgpu_last_pop_error_scope_message_len_u64 != 0u) {
+    memcpy(out, g_mbt_wgpu_last_pop_error_scope_message,
+           (size_t)g_mbt_wgpu_last_pop_error_scope_message_len_u64);
+  }
+  return 1;
 }
 
 void mbt_wgpu_command_encoder_set_label_utf8(WGPUCommandEncoder encoder,

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1922,6 +1922,7 @@ pub fn Device::missing_rust_features_u64(Self, UInt64) -> UInt64
 pub fn Device::poll(Self, wait? : Bool) -> Bool
 pub fn Device::poll_raw(Self, Bool, @c.WGPUSubmissionIndexPtr) -> Bool
 pub fn Device::pop_error_scope_sync(Self, Instance) -> UInt
+pub fn Device::pop_error_scope_sync_result(Self, Instance) -> ErrorScopeResult
 pub fn Device::push_error_scope(Self, UInt) -> Unit
 pub fn Device::push_error_scope_raw(Self, @c.WGPUErrorFilter) -> Unit
 pub fn Device::queue(Self) -> Queue
@@ -1939,6 +1940,11 @@ pub fn Device::supports_rust_features_u64(Self, UInt64) -> Bool
 pub fn Device::take_lost_reason(Self) -> UInt
 pub fn Device::unknown_rust_features_u64(Self, UInt64) -> UInt64
 pub fn Device::wait_lost_reason_sync(Self, Instance) -> UInt
+
+pub struct ErrorScopeResult {
+  error_type : UInt
+  message : String
+}
 
 pub struct GlobalReport {
   raw : @c.WGPUGlobalReportPtr

--- a/src/tests/wgpu_error_scope_test.mbt
+++ b/src/tests/wgpu_error_scope_test.mbt
@@ -24,3 +24,19 @@ test "wgpu device error scopes (validation)" {
   adapter.release()
   instance.release()
 }
+
+///|
+test "wgpu device error scope result exposes validation message" {
+  let instance = @wgpu.Instance::create()
+  let adapter = instance.request_adapter_sync()
+  let device = adapter.request_device_sync(instance)
+  device.push_error_scope(@wgpu.ERROR_FILTER_VALIDATION)
+  let shader = device.create_shader_module_wgsl("fn")
+  let result = device.pop_error_scope_sync_result(instance)
+  inspect(result.error_type == @wgpu.ERROR_TYPE_VALIDATION, content="true")
+  inspect(result.message.length() > 0, content="true")
+  shader.release()
+  device.release()
+  adapter.release()
+  instance.release()
+}

--- a/src/wgpu_device.mbt
+++ b/src/wgpu_device.mbt
@@ -43,6 +43,20 @@ pub fn Device::pop_error_scope_sync(self : Device, instance : Instance) -> UInt 
 }
 
 ///|
+pub fn Device::pop_error_scope_sync_result(
+  self : Device,
+  instance : Instance,
+) -> ErrorScopeResult {
+  let error_type = self.pop_error_scope_sync(instance)
+  ErrorScopeResult::{
+    error_type,
+    message: read_utf8_via(
+      @c.device_pop_error_scope_sync_last_message_utf8_len, @c.device_pop_error_scope_sync_last_message_utf8,
+    ),
+  }
+}
+
+///|
 pub fn Device::supported_features_count_u64(self : Device) -> UInt64 {
   @c.device_supported_features_count_u64(self.raw)
 }

--- a/src/wgpu_spec_extras.mbt
+++ b/src/wgpu_spec_extras.mbt
@@ -1722,6 +1722,13 @@ declare pub fn Device::pop_error_scope_sync(
 
 ///|
 #declaration_only
+declare pub fn Device::pop_error_scope_sync_result(
+  self : Device,
+  instance : Instance,
+) -> ErrorScopeResult
+
+///|
+#declaration_only
 declare pub fn Device::supported_features_count_u64(self : Device) -> UInt64
 
 ///|

--- a/src/wgpu_types.mbt
+++ b/src/wgpu_types.mbt
@@ -401,6 +401,12 @@ pub struct CompilationInfo {
 }
 
 ///|
+pub struct ErrorScopeResult {
+  error_type : UInt
+  message : String
+}
+
+///|
 pub fn platform_is_macos() -> Bool {
   @c.platform_is_macos()
 }


### PR DESCRIPTION
## Summary
- add ErrorScopeResult with error type and validation message
- expose Device::pop_error_scope_sync_result while preserving the existing numeric API
- retain the pop error scope callback message in the C sync helper and add coverage for shader validation messages

Fixes #14

## Verification
- moon check
- moon test src/tests/wgpu_error_scope_test.mbt
- moon test src/tests
- moon test src/tests_macos
- moon info && moon fmt

Note: full moon test was also run and still fails in the existing cross-platform/runtime cases for Linux/Windows surface/headless tests on this host.