### PR TITLE
Allow empty bind groups in builder

### DIFF
--- a/src/c/wgpu_stub_descs_pipelines.c
+++ b/src/c/wgpu_stub_descs_pipelines.c
@@ -3994,9 +3994,6 @@ static void mbt_wgpu_bind_group_builder_finalize(void *self) {
 }
 
 void *mbt_wgpu_bind_group_builder_new(uint64_t max_entries) {
-  if (max_entries == 0u) {
-    return NULL;
-  }
   mbt_bind_group_builder_t *b =
       (mbt_bind_group_builder_t *)moonbit_make_external_object(
           mbt_wgpu_bind_group_builder_finalize,
@@ -4008,6 +4005,9 @@ void *mbt_wgpu_bind_group_builder_new(uint64_t max_entries) {
   b->len = 0u;
   b->entries = NULL;
   b->extras = NULL;
+  if (max_entries == 0u) {
+    return (void *)b;
+  }
   b->entries =
       (WGPUBindGroupEntry *)calloc((size_t)max_entries, sizeof(WGPUBindGroupEntry));
   if (!b->entries) {
@@ -4245,7 +4245,10 @@ WGPUBindGroup mbt_wgpu_bind_group_builder_finish(WGPUDevice device,
                                                 void *builder, const uint8_t *label,
                                                 uint64_t label_len) {
   mbt_bind_group_builder_t *b = (mbt_bind_group_builder_t *)builder;
-  if (!device || !layout || !b || !b->entries || b->len == 0u) {
+  if (!device || !layout || !b) {
+    return NULL;
+  }
+  if (b->len != 0u && !b->entries) {
     return NULL;
   }
   WGPUBindGroupDescriptor desc = {
@@ -4253,7 +4256,7 @@ WGPUBindGroup mbt_wgpu_bind_group_builder_finish(WGPUDevice device,
       .label = mbt_wgpu_string_view(label, label_len),
       .layout = layout,
       .entryCount = (size_t)b->len,
-      .entries = b->entries,
+      .entries = b->len == 0u ? NULL : b->entries,
   };
   WGPUBindGroup out = wgpuDeviceCreateBindGroup(device, &desc);
   mbt_wgpu_bind_group_builder_drop(b);

--- a/src/tests/wgpu_bind_group_builder_storage_buffer_test.mbt
+++ b/src/tests/wgpu_bind_group_builder_storage_buffer_test.mbt
@@ -74,3 +74,74 @@ test "wgpu bind group builder (storage buffer)" {
   adapter.release()
   instance.release()
 }
+
+///|
+test "wgpu bind group builder creates zero-entry bind group" {
+  let instance = @wgpu.Instance::create()
+  let adapter = instance.request_adapter_sync()
+  let device = adapter.request_device_sync(instance)
+  let queue = device.queue()
+  let storage_usage = @wgpu.BUFFER_USAGE_STORAGE |
+    @wgpu.BUFFER_USAGE_COPY_SRC |
+    @wgpu.BUFFER_USAGE_COPY_DST
+  let readback_usage = @wgpu.BUFFER_USAGE_MAP_READ | @wgpu.BUFFER_USAGE_COPY_DST
+  let storage = device.create_buffer(size=4UL, usage=bu(storage_usage))
+  let readback = device.create_buffer(size=256UL, usage=bu(readback_usage))
+  let storage_layout_builder = @wgpu.BindGroupLayoutBuilder::new(
+    max_entries=1UL,
+  )
+  let storage_layout_ok = storage_layout_builder.add_buffer(
+    0U,
+    ss(@wgpu.SHADER_STAGE_COMPUTE),
+    @wgpu.BUFFER_BINDING_TYPE_STORAGE,
+  )
+  inspect(storage_layout_ok, content="true")
+  let storage_layout = storage_layout_builder.finish(device)
+  let empty_layout = device.create_bind_group_layout_empty()
+  let storage_group_builder = @wgpu.BindGroupBuilder::new(max_entries=1UL)
+  let storage_group_ok = storage_group_builder.add_buffer(0U, storage)
+  inspect(storage_group_ok, content="true")
+  let storage_group = storage_group_builder.finish(device, storage_layout)
+  let empty_group_builder = @wgpu.BindGroupBuilder::new(max_entries=0UL)
+  let empty_group = empty_group_builder.finish(device, empty_layout)
+  let pl = device.create_pipeline_layout_2(storage_layout, empty_layout)
+  let wgsl : String =
+    #|@group(0) @binding(0) var<storage, read_write> out: array<u32>;
+    #|
+    #|@compute @workgroup_size(1)
+    #|fn main() {
+    #|  out[0] = 11u;
+    #|}
+    #|
+  let sm = device.create_shader_module_wgsl(wgsl)
+  let cp = device.create_compute_pipeline_with_layout(pl, sm)
+  let encoder = device.create_command_encoder()
+  let pass = encoder.begin_compute_pass()
+  pass.set_pipeline(cp)
+  pass.set_bind_group(0U, storage_group, [])
+  pass.set_bind_group(1U, empty_group, [])
+  pass.dispatch_workgroups(1U, 1U, 1U)
+  pass.end()
+  pass.release()
+  encoder.copy_buffer_to_buffer(storage, 0UL, readback, 0UL, 4UL)
+  let cmd = encoder.finish()
+  queue.submit_one(cmd)
+  let _done = device.poll(wait=true)
+  let out = readback.readback(instance, 0UL, 4UL)
+  inspect(u32le_at(out, 0), content="11")
+  cmd.release()
+  encoder.release()
+  cp.release()
+  sm.release()
+  pl.release()
+  empty_group.release()
+  storage_group.release()
+  empty_layout.release()
+  storage_layout.release()
+  readback.release()
+  storage.release()
+  queue.release()
+  device.release()
+  adapter.release()
+  instance.release()
+}


### PR DESCRIPTION
## Summary
- allow BindGroupBuilder::new(max_entries=0) to create a valid empty builder
- allow BindGroupBuilder::finish to produce entryCount=0 / entries=NULL descriptors
- add a compute pipeline regression test that binds an empty group in a reserved group slot

Fixes #16

## Verification
- moon check
- moon test src/tests/wgpu_bind_group_builder_storage_buffer_test.mbt
- moon info && moon fmt
- moon test src/tests
- moon test src/tests_macos

Full moon test was also run; it still fails in the existing Linux/Windows cross-platform runtime cases on this host (adapter request/surface contract), unrelated to this change.